### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Below are example usage patterns for the MDEAutomator PowerShell module.
 ### Importing
 ```powershell
 # Import MDEAutomator module
-Import-Module -Name ./MDEAutomator -ErrorAction Stop -Force
+Import-Module -Name ./function/MDEAutomator -ErrorAction Stop -Force
 
 ```
 > **Note:** PowerShell Gallery support is planned & in-progress


### PR DESCRIPTION
Adding 'function' to import-module path to successfully import the module and fix error: 

Import-Module: The specified module './MDEAutomator' was not loaded because no valid module file was found in any module directory.

New command:

Import-Module -Name ./function/MDEAutomator -ErrorAction Stop -Force